### PR TITLE
Change supported versions of Django and Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,32 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
-  - 3.2
   - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 env:
-  - DJANGO=1.5.10
-  - DJANGO=1.6.7
-  - DJANGO=1.7
+  - DJANGO=1.8
+  - DJANGO=1.9
+  - DJANGO=1.10
+  - DJANGO=1.11
 
 matrix:
   exclude:
-    - python: 2.6
-      env: DJANGO=1.7
+    - python: 3.3
+      env: DJANGO=1.9
+    - python: 3.3
+      env: DJANGO=1.10
+    - python: 3.3
+      env: DJANGO=1.11
+    - python: 3.6
+      env: DJANGO=1.8
+    - python: 3.6
+      env: DJANGO=1.9
+    - python: 3.6
+      env: DJANGO=1.10
 
 install:
   - pip install Django==$DJANGO

--- a/django_tinsel/decorators.py
+++ b/django_tinsel/decorators.py
@@ -10,8 +10,7 @@ from functools import wraps
 from django.contrib.auth import get_user_model
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, Http404)
-from django.shortcuts import get_object_or_404, render_to_response
-from django.template import RequestContext
+from django.shortcuts import get_object_or_404, render
 
 from django_tinsel.exceptions import HttpBadRequestException
 from django_tinsel.utils import LazyEncoder
@@ -83,8 +82,7 @@ def render_template(template):
             # If we want to return some other response type we can,
             # that simply overrides the default behavior
             if params is None or isinstance(params, dict):
-                resp = render_to_response(template, params,
-                                          RequestContext(request), **kwargs)
+                resp = render(request, template, params, **kwargs)
             else:
                 resp = params
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
         "Framework :: Django",
         "License :: OSI Approved :: Apache Software License"
     ],
-    install_requires=['django>=1.5'],
+    install_requires=['django>=1.8'],
 )

--- a/test_app/test_app/settings.py
+++ b/test_app/test_app/settings.py
@@ -12,4 +12,12 @@ INSTALLED_APPS = ('django.contrib.auth',
                   'django.contrib.contenttypes',
                   'django_tinsel_tests',)
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+    },
+]
+
 DEBUG = True


### PR DESCRIPTION
 - Added support for Django 1.8 - 1.11, dropped support for 1.5-1.7
   - Switched from `render_to_response` (which is deprecated on Django 1.10+) to `render`
 - Added support for Python 3.4 - 3.6, dropped support for 2.6 and 3.2