### PR TITLE
Declare to PyPI and tools that django-tinsel supports Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 env:
   - DJANGO=1.8
@@ -18,6 +20,18 @@ matrix:
     - python: 3.6
       env: DJANGO=1.9
     - python: 3.6
+      env: DJANGO=1.10
+    - python: 3.7
+      env: DJANGO=1.8
+    - python: 3.7
+      env: DJANGO=1.9
+    - python: 3.7
+      env: DJANGO=1.10
+    - python: 3.8
+      env: DJANGO=1.8
+    - python: 3.8
+      env: DJANGO=1.9
+    - python: 3.8
       env: DJANGO=1.10
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
   - 3.6
 
@@ -15,12 +13,6 @@ env:
 
 matrix:
   exclude:
-    - python: 3.3
-      env: DJANGO=1.9
-    - python: 3.3
-      env: DJANGO=1.10
-    - python: 3.3
-      env: DJANGO=1.11
     - python: 3.6
       env: DJANGO=1.8
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         "Environment :: Plugins",
         "Framework :: Django",
         "License :: OSI Approved :: Apache Software License"

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         "Environment :: Plugins",
         "Framework :: Django",
         "License :: OSI Approved :: Apache Software License"


### PR DESCRIPTION
We add the "trove classifiers" matching the versions listed in the TravisCI
build matrix so that tools like `caniusepython3` will list the library as
supported.

https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3